### PR TITLE
AP_OpticalFlow: detect Pixart on ChibiOS

### DIFF
--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -92,8 +92,9 @@ void OpticalFlow::init(void)
 #if AP_FEATURE_BOARD_DETECT
         if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXHAWK ||
             AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXHAWK2 ||
-            AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PCNC1) {
-            // possibly have pixhart on external SPI
+            AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PCNC1 ||
+            AP_BoardConfig::get_board_type() == AP_BoardConfig::HAL_BOARD_CHIBIOS) {
+            // possibly have pixart on external SPI
             backend = AP_OpticalFlow_Pixart::detect("pixartflow", *this);
         }
         if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_SP01) {
@@ -108,8 +109,6 @@ void OpticalFlow::init(void)
         backend = new AP_OpticalFlow_Onboard(*this);
 #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
         backend = AP_OpticalFlow_PX4Flow::detect(*this);
-#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_SKYVIPER_F412
-        backend = AP_OpticalFlow_Pixart::detect("pixartflow", *this);
 #endif
     }
 

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -109,6 +109,8 @@ void OpticalFlow::init(void)
         backend = new AP_OpticalFlow_Onboard(*this);
 #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
         backend = AP_OpticalFlow_PX4Flow::detect(*this);
+#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_SKYVIPER_F412	
+        backend = AP_OpticalFlow_Pixart::detect("pixartflow", *this);
 #endif
     }
 


### PR DESCRIPTION
This allows auto detection of the pixart flow sensor (external SPI) on all chibios boards.
Not all boards have an exposed external SPI (ie Cube on standard carrier), however this change should not have a negative impact.
Also removes redundant elif for skyviper f412 subtype, as it's a chibios target and will be captured by the broader change.